### PR TITLE
Rework ERD and Entity Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ When searching for service providers, the expected results is:
 #### Refactoring
 
 - Refactor the response model for the customer stream pickup registration.
-- Refactor Customer streams registration use case.
+- Refactor Customer stream pickup registration use case.
     - Can you guard against business invariants?
 
 #### Opportunities
@@ -164,7 +164,7 @@ When searching for service providers, the expected results is:
 - Implement a Database Provider.
 - Implement caching strategy.
 - Can you apply a better design pattern for the overall registration and data modeling?
-- Show us your understanding of Domain Driven Design and Loose Coupling?
+- Can you show us your understanding of Domain Driven Design and Loose Coupling?
 - Can you spot opportunities for a `read-model`?
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ service providers and another to register the collection.
 We have divided the assignment into what we called "gates", these gates are references to engineering skills that we are
 looking for in a future colleague.
 Some of them are required, some of them give you bonus points.
-Depending on your seniority, points are added or deducted based off your choices.
 
-We purposely made this project framework agnostic and it only contains the bare minimum to perform the necessary use
-cases.
+We purposely made this project framework-agnostic, and it only contains the bare minimum to perform the necessary use
+cases but make sure to apply the same concepts that you would use in a real-world scenario when exposing an
+API.
 
 ## The output
 
@@ -40,72 +40,82 @@ Although experience with these technologies is not a requirement to join our tea
 able to work in this ecosystem. Your own experience will be taken into account when reviewing your assignment, so no
 need to panic if you are not familiar with them.
 
-You can complete the assingment using the following ecosystems:
+You can complete the assignment using the following ecosystems:
 
 - Node JS/TS
 - .NET (Core) 5+
 - Java / Kotlin
+- Python
 
 ## Data Model Representation
 
+### Waste Stream
+
+A Waste Stream can be described as:
+A specific type of waste that can be collected by a Service Provider and is registered for collection by a Customer.
+
+| id | label |
+|:--:|:-----:|
+| 1  | paper |
+| 2  | metal |
+| 3  | glass |
+
 ### Service Provider
 
-A Service Provider can be described as:
+Can be described as:
 A business that can collect a specific set of waste streams.
 
-| id |      name      |                 address                 | covered streams |
-|:--:|:--------------:|:---------------------------------------:|:---------------:|
-| 1  |    Rewaste     |   Stationplein, 1, 1012 AB Amsterdam    |     [1, 2]      |
-| 2  | Bluecollection | Prins Hendrikkade, 1, 1012 JD Amsterdam |       [3]       |
+| id |      name      |                 address                 | coverages |
+|:--:|:--------------:|:---------------------------------------:|:---------:|
+| 1  |    Unwasted    |   Stationplein, 1, 1012 AB Amsterdam    |  [1, 2]   |
+| 2  | Bluecollection | Prins Hendrikkade, 1, 1012 JD Amsterdam |    [3]    |
 
-#### Service Provider Coverage
+We have two service providers, "Unwasted" and "Bluecollection".
 
-Service provider coverage can be described as:
-The streams in which a service provider has covered in a postal code range, for a given date availability.
+### Service Provider Coverage
 
-| id | stream_id | postal_code_start | postal_code_end |  availability   |
-|:--:|:---------:|:-----------------:|:---------------:|:---------------:|
-| 1  |   paper   |       1010        |      1020       |    [1, 2, 3]    |
-| 2  |   metal   |       1010        |      1020       |   [1, 4, 5 ]    |
-| 3  |   metal   |       1000        |      9999       | [1, 2, 3, 4, 5] |
+Can be described as:
+The waste streams in which a service provider has covered in a postal code range, for a given set of weekdays.
 
-#### Coverage Availability
+| id |  stream  | postal_code_start | postal_code_end |               availability_dates               |
+|:--:|:--------:|:-----------------:|:---------------:|:----------------------------------------------:|
+| 1  | paper(1) |       1010        |      1020       |          [Monday, Tuesday, Thursday]           |
+| 2  | metal(2) |       1010        |      1020       |          [Monday, Wednesday, Friday]           |
+| 3  | metal(2) |       1000        |      9999       | [Monday, Tuesday, Wednesday, Thursday, Friday] |
 
-Coverage availability can be described as:
-A simple Date reference of an availability calendar.
+This means that "Unwasted" can:
 
-| id |    date    |
-|:--:|:----------:|
-| 1  | 2023-10-01 |
-| 2  | 2023-10-02 |
-| 3  | 2023-10-03 |
-| 4  | 2023-10-04 |
-| 5  | 2023-10-05 |
+- Collect Paper in the postal code range 1010-1020 on [Monday, Tuesday, Wednesday] .
+- Collect Metal in the postal code range 1010-1020 on [Monday, Wednesday, Friday].
+
+While "Bluecollection" can:
+
+- Collect Metal in the postal code range 0000-9999 on [Monday, Tuesday, Wednesday, Thursday, Friday].
 
 ---
 
 ### Customer
 
-A Customer can be described as:
+Can be described as:
 A person or business entity that has waste to be collected at a given address.
 
-| id |     name      |                  address                  | streams |
-|:--:|:-------------:|:-----------------------------------------:|:-------:|
-| 1  |    Seenons    |    Danzigerkade 5B, 1013 AP Amsterdam     |   [1]   |
-| 1  | Mega City One | Prins Hendrikkade, 100, 1012 JD Amsterdam |  [2,3]  |
+| id |     name      |                  address                  | registered_stream_pickups |
+|:--:|:-------------:|:-----------------------------------------:|:-------------------------:|
+| 1  |    Seenons    |    Danzigerkade 5B, 1013 AP Amsterdam     |            [1]            |
+| 1  | Mega City One | Prins Hendrikkade, 100, 1012 JD Amsterdam |          [2, 3]           |
 
-#### Customer Streams
+#### Registered Stream Pickups
 
-A Customer Stream can be described as:
-A registered stream pickup for a customer to be performed by a Service Provider at a given date and how many containers.
+Can be described as:
+A "scheduled" pickup registered by a customer to be performed by a Service Provider at a given date
 
-| id | stream_id | service_provider_id | pickup_date | quantity |
-|:--:|:---------:|:-------------------:|-------------|----------|
-| 1  |   paper   |          1          | 2023-10-01  | 1        |
-| 2  |   metal   |          2          | 2023-10-01  | 1        |
-| 3  |   metal   |          2          | 2023-10-02  | 1        |
+| id | stream_id | service_provider_id | pickup_date |
+|:--:|:---------:|:-------------------:|-------------|
+| 1  |   paper   |          1          | 2023-10-01  |
+| 2  |   metal   |          2          | 2023-10-01  |
+| 3  |   metal   |          2          | 2023-10-02  |
 
-## Gates
+## Evaluation Gates
 
 1. Implementation
 2. Refactoring
@@ -119,22 +129,21 @@ A registered stream pickup for a customer to be performed by a Service Provider 
 - Implement the customer stream pickup registration.
 - Implement the use case to retrieve which service providers are available at a given location and date.
 
-#### Expectation
+#### Expectations
 
 When registering a stream pick up, at least the following requirements must be met:
 
-- Ensure the Service Provider exists
-- Ensure the Stream exists
-- Ensure availability
+- Ensure that said Stream can be picked up by the Service Provider at the given date
 
 When searching for service providers, the expected results is:
 
-| postal_code |    date    | result                                          |
-|:-----------:|:----------:|-------------------------------------------------|
-|    1010     | 2023-10-01 | [Rewaste (paper, metal), Bluecollection(metal)] |
-|    1010     | 2023-10-04 | [Rewaste(metal) , Bluecollection(metal)]        |
-|    2000     | 2023-10-05 | [Bluecollection(metal)]                         |
-|    2000     | 2023-10-06 | []                                              |
+| postal_code |          date          |                      result                      |
+|:-----------:|:----------------------:|:------------------------------------------------:|
+|    1010     |  2023-10-02 (Monday)   | [Unwasted (paper, metal), Bluecollection(metal)] |
+|    1010     | 2023-10-04 (Wednesday) |    [Unwasted(metal) , Bluecollection(metal)]     |
+|    2000     | 2023-10-05 (Thursday)  |             [Bluecollection(metal)]              |
+|    1010     |  2023-10-08 (Sunday)   |                        []                        |
+|    0000     |  2023-10-03 (Tuesday)  |                        []                        |
 
 #### Testability
 
@@ -151,15 +160,16 @@ When searching for service providers, the expected results is:
 
 #### Opportunities
 
-- Enhance testing capabilities and reusability.
+- Enhance testing capabilities and re-usability.
 - Implement a Database Provider.
 - Implement caching strategy.
 - Can you apply a better design pattern for the overall registration and data modeling?
-- Show us your understanding of Domain Driven Design and Loose Coupling.
+- Show us your understanding of Domain Driven Design and Loose Coupling?
 - Can you spot opportunities for a `read-model`?
 
 ## Disclaimer
 
 Please note that this assignment is not a direct representation of how Seenons built its software.
 
-The assignment is meant for all levels of seniority in mind, so the concepts, patterns, domain models and tools have been simplified to ensure fairness.
+The assignment is meant for all levels of seniority in mind, so the concepts, patterns, domain models and tools have
+been simplified to ensure fairness.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ We have two service providers, "Unwasted" and "Bluecollection".
 Can be described as:
 The waste streams in which a service provider has covered in a postal code range, for a given set of weekdays.
 
-| id |  stream  | postal_code_start | postal_code_end |               availability_dates               |
+| id |  stream  | postal_code_start | postal_code_end |              weekday_availability              |
 |:--:|:--------:|:-----------------:|:---------------:|:----------------------------------------------:|
 | 1  | paper(1) |       1010        |      1020       |          [Monday, Tuesday, Thursday]           |
 | 2  | metal(2) |       1010        |      1020       |          [Monday, Wednesday, Friday]           |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ ecosystems below.
 - Java / Kotlin
 - Python
 
+Would you rather do it in another language? Let us know beforehand!
+
 ## Data Model Representation
 
 ### Waste Stream

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ A "scheduled" pickup registered by a customer to be performed by a Service Provi
 
 | id | stream_id | service_provider_id | pickup_date |
 |:--:|:---------:|:-------------------:|-------------|
-| 1  |   paper   |          1          | 2023-10-01  |
-| 2  |   metal   |          2          | 2023-10-01  |
-| 3  |   metal   |          2          | 2023-10-02  |
+| 1  |   paper   |          1          | 2023-10-02  |
+| 2  |   metal   |          2          | 2023-10-04  |
+| 3  |   metal   |          2          | 2023-10-06  |
 
 ## Evaluation Gates
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ This project is built using the following technologies:
 - TypeScript
 
 Although experience with these technologies is not a requirement to join our team, we are looking for people who will be
-able to work in this ecosystem. Your own experience will be taken into account when reviewing your assignment, so no
-need to panic if you are not familiar with them.
+able to work in this ecosystem, so we recommend you to use them.
 
-You can complete the assignment using the following ecosystems:
+If you are not familiar with these technologies, please let us know, you can also complete the assignment using the
+ecosystems below.
 
-- Node JS/TS
 - .NET (Core) 5+
 - Java / Kotlin
 - Python
@@ -104,7 +103,7 @@ A person or business entity that has waste to be collected at a given address.
 | 1  |    Seenons    |    Danzigerkade 5B, 1013 AP Amsterdam     |            [1]            |
 | 1  | Mega City One | Prins Hendrikkade, 100, 1012 JD Amsterdam |          [2, 3]           |
 
-#### Registered Stream Pickups
+### Registered Stream Pickups
 
 Can be described as:
 A "scheduled" pickup registered by a customer to be performed by a Service Provider at a given date
@@ -150,13 +149,13 @@ When searching for service providers, the expected results is:
 - Ensure completeness of the Register Stream Service Spec.
 - Ensure completeness of the Service Providers Availability Spec.
 
-### Bonus points
+### Bonus Points (not require but recommended)
 
 #### Refactoring
 
 - Refactor the response model for the customer stream pickup registration.
 - Refactor Customer stream pickup registration use case.
-    - Can you guard against business invariants?
+    - Can you find and guard against business invariants?
 
 #### Opportunities
 

--- a/src/providers/entities/coverage_availability.entity.ts
+++ b/src/providers/entities/coverage_availability.entity.ts
@@ -1,4 +1,0 @@
-export class CoverageAvailabilityEntity {
-  id!: string;
-  date!: Date;
-}

--- a/src/providers/entities/customer.entity.ts
+++ b/src/providers/entities/customer.entity.ts
@@ -1,8 +1,8 @@
-import { CustomerStreamsEntity } from './customer_streams.entity';
+import { RegisteredStreamPickupEntity } from './customer_streams.entity';
 
 export class CustomerEntity {
   id!: string;
   name!: string;
   address!: string;
-  streams!: CustomerStreamsEntity[];
+  registered_stream_pickups!: RegisteredStreamPickupEntity[];
 }

--- a/src/providers/entities/customer_streams.entity.ts
+++ b/src/providers/entities/customer_streams.entity.ts
@@ -1,11 +1,9 @@
-/*
-  4. Opportunity
-  Can you spot missing references in the CustomerStreamsEntity?
-*/
-export class CustomerStreamsEntity {
+import { WasteStreamEntity } from './waste_stream.entity';
+import { ServiceProviderEntity } from './service_provider.entity';
+
+export class RegisteredStreamPickupEntity {
   id!: string;
-  stream_id!: string;
-  service_provider_id!: string;
+  waste_stream!: WasteStreamEntity;
+  service_provider!: ServiceProviderEntity;
   pickup_date!: Date;
-  quantity!: number;
 }

--- a/src/providers/entities/service_provider_coverage.entity.ts
+++ b/src/providers/entities/service_provider_coverage.entity.ts
@@ -1,10 +1,19 @@
-import { CoverageAvailabilityEntity } from './coverage_availability.entity';
-import { StreamEntity } from './stream.entity';
+import { WasteStreamEntity } from './waste_stream.entity';
 
 export class ServiceProviderCoverageEntity {
   id!: string;
-  stream!: StreamEntity;
+  waste_stream!: WasteStreamEntity;
   postal_code_start!: string;
   postal_code_end!: string;
-  coverage_availability!: CoverageAvailabilityEntity[];
+  weekday_availability!: Weekday[];
+}
+
+export enum Weekday {
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6,
+  Sunday = 7
 }

--- a/src/providers/entities/waste_stream.entity.ts
+++ b/src/providers/entities/waste_stream.entity.ts
@@ -1,4 +1,4 @@
-export class StreamEntity {
+export class WasteStreamEntity {
   id!: string;
   label!: string;
 }

--- a/src/services/availability/service_provider_availability.service.spec.ts
+++ b/src/services/availability/service_provider_availability.service.spec.ts
@@ -14,10 +14,19 @@ describe('ServiceProviderAvailabilityService', () => {
   });
 
   describe('findAvailabilityAt', () => {
-    it(`should return empty list if no service providers are available for postal code #X`, () => {});
+    it(`should return [Unwasted (paper, metal), Bluecollection(metal)] for postal code 1010 on a Monday (2023-10-02)`, () => {
+    });
 
-    it(`should return empty list if no service providers are available at date $y`, () => {});
+    it(`should return [Unwasted(metal) , Bluecollection(metal)] for postal code 1010 on a Wednesday (2023-10-04)`, () => {
+    });
 
-    it(`should return a list of service providers that are available for postal code #X at date $y`, () => {});
+    it(`should return [Bluecollection(metal)] for postal code 2000 on a Thursday (2023-10-05)`, () => {
+    });
+
+    it(`should return empty list if no service providers are available for postal code 1010 on a Sunday (2023-10-08)`, () => {
+    });
+
+    it(`should return empty list if no service providers are available at postal code 0000`, () => {
+    });
   });
 });

--- a/src/services/customer/register_stream.service.spec.ts
+++ b/src/services/customer/register_stream.service.spec.ts
@@ -1,5 +1,7 @@
 import { RegisterStreamService } from './register_stream.service';
 import { CustomerRepository } from '../../providers/adapters/customer.repository';
+import { WasteStreamEntity } from '../../providers/entities/waste_stream.entity';
+import { ServiceProviderEntity } from '../../providers/entities/service_provider.entity';
 
 //3. Testability
 describe('RegisterStreamService', () => {
@@ -24,7 +26,6 @@ describe('RegisterStreamService', () => {
         'stream-id',
         'service-provider-id',
         new Date(),
-        5,
       );
 
       expect(response).toEqual({
@@ -34,23 +35,24 @@ describe('RegisterStreamService', () => {
     });
 
     it(`should throw an error if the stream doesn't exist`, () => {
-      throw new Error('Not implemented');
+
     });
 
     it(`should throw an error if the service provider doesn't exist`, () => {
-      throw new Error('Not implemented');
+
     });
 
     it(`should throw an error if the pickup date is not available for the service provider`, () => {
-      throw new Error('Not implemented');
+      
     });
 
+    //1. Implementation
     it(`should register the stream`, () => {
       jest.spyOn(customerRepository, 'findById').mockReturnValueOnce({
         id: 'customer-id',
         name: 'customer-name',
         address: 'customer-address',
-        streams: [],
+        registered_stream_pickups: [],
       });
 
       jest.spyOn(customerRepository, 'save').mockReturnValueOnce(undefined);
@@ -59,27 +61,26 @@ describe('RegisterStreamService', () => {
         'customer-id',
         'stream-id',
         'service-provider-id',
-        new Date('2023-01-01'),
-        5,
+        new Date('2023-01-02'),
       );
 
       expect(response).toEqual({
         id: 'customer-id',
         name: 'customer-name',
         address: 'customer-address',
-        streams: [
+        registered_stream_pickups: [
           {
             id: expect.any(String),
-            stream_id: 'stream-id',
-            service_provider_id: 'service-provider-id',
-            pickup_date: new Date('2023-01-01'),
-            quantity: 5,
+            waste_stream: new WasteStreamEntity(),
+            service_provider: new ServiceProviderEntity(),
+            pickup_date: new Date('2023-01-02'),
           },
         ],
       });
     });
 
     //4. Opportunities
-    it(`should update the previous stream if it already exists`, () => {});
+    it(`should update the previous stream if it already exists`, () => {
+    });
   });
 });

--- a/src/services/customer/register_stream.service.ts
+++ b/src/services/customer/register_stream.service.ts
@@ -1,6 +1,8 @@
 import { CustomerRepository } from '../../providers/adapters/customer.repository';
 import { CustomerEntity } from '../../providers/entities/customer.entity';
 import * as crypto from 'crypto';
+import { WasteStreamEntity } from '../../providers/entities/waste_stream.entity';
+import { ServiceProviderEntity } from '../../providers/entities/service_provider.entity';
 
 /*
   2. Refactoring
@@ -8,18 +10,18 @@ import * as crypto from 'crypto';
 export type RegisterStreamResponse =
   | CustomerEntity
   | {
-      error: string;
-    };
+  error: string;
+};
 
 export class RegisterStreamService {
-  constructor(private readonly customerRepository: CustomerRepository) {}
+  constructor(private readonly customerRepository: CustomerRepository) {
+  }
 
   public registerStream(
     customerId: string,
     streamId: string,
     serviceProviderId: string,
     pickupDate: Date,
-    quantity: number,
   ): RegisterStreamResponse {
     const customer = this.customerRepository.findById(customerId);
 
@@ -42,12 +44,11 @@ export class RegisterStreamService {
       - Can you spot improvements to avoid duplicates? (immutability vs mutability perhaps?)
     */
 
-    customer.streams.push({
+    customer.registered_stream_pickups.push({
       id: crypto.randomUUID(),
-      stream_id: streamId,
-      service_provider_id: serviceProviderId,
+      waste_stream: new WasteStreamEntity(),
+      service_provider: new ServiceProviderEntity(),
       pickup_date: pickupDate,
-      quantity: quantity,
     });
 
     this.customerRepository.save(customer);


### PR DESCRIPTION
Based off a candidate's feedback, I'm fixing the pseudo ERD and how the entities are represented;


- Now instead of have a date availability, the Coverage has a reference of the Weekdays in which the Service Provider can perform the collection
- Renamed Customer Stream to Registered Stream Pickup
- Allowed Python to be a deliverable
- Using entity references instead of Ids to better match an Entity Relationship
- Renamed Stream to WasteStream
- Added test use cases that the candidate must fulfil as a deliverable (part of the expectation)
- Fixed typos and removed duplicated texts
